### PR TITLE
add asBackgroundShade logic

### DIFF
--- a/apps/fabric-examples/src/pages/ThemerPage/ThemerPage.tsx
+++ b/apps/fabric-examples/src/pages/ThemerPage/ThemerPage.tsx
@@ -352,7 +352,7 @@ export class ThemerPage extends React.Component<any, any> {
       <div className='ms-themer-paletteSlot' key={ baseSlot }>
         <h3>{ BaseSlots[baseSlot] }</h3>
         <ColorPicker
-          key={ "baseslotcolorpicker" + baseSlot }
+          key={ 'baseslotcolorpicker' + baseSlot }
           color={ this.state.themeRules[BaseSlots[baseSlot]].value.str }
           onColorChanged={ _onColorChanged.bind(this) } />
         <div className='ms-themer-swatchBg' style={ { backgroundColor: this.state.themeRules[BaseSlots[baseSlot]].value.str } }>

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/IThemeSlotRule.ts
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/IThemeSlotRule.ts
@@ -10,6 +10,8 @@ export interface IThemeSlotRule {
   inherits?: IThemeSlotRule;
   /* If set, this slot is the specified shade of the slot it inherits from. */
   asShade?: Shade;
+  /* Whether this slot is a background shade, which uses different logic for generating its inheriting-as-shade value. */
+  isBackgroundShade?: boolean;
   /* Whether this slot has been manually overridden (else, it was automatically generated based on inheritance). */
   isCustomized?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGenerator.ts
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGenerator.ts
@@ -2,7 +2,11 @@ import {
   IColor,
   getColorFromString
 } from '../../utilities/color/Colors';
-import { isValidShade, getShade } from '../../utilities/color/Shades';
+import {
+  isValidShade,
+  getShade,
+  getBackgroundShade
+} from '../../utilities/color/Shades';
 import { format } from '../../Utilities';
 
 import { IThemeSlotRule } from './IThemeSlotRule';
@@ -91,7 +95,7 @@ export class ThemeGenerator {
     return output;
   }
 
-  /* Sets the given slot's value to the given value, shading it if necessary.
+  /* Sets the given slot's value to the appropriate value, shading it if necessary.
      Then, iterates through all other rules (that are this rule's dependents) to update them accordingly. */
   private static _setSlot(
     rule: IThemeSlotRule,
@@ -104,8 +108,12 @@ export class ThemeGenerator {
       if (isCustomized || !isValidShade(rule.asShade)) {
         // if it's customized (or the rule is invalid), just set it to the raw value
         rule.value = value;
-      } else { // not customized, so use the asShade +
-        rule.value = getShade(value, rule.asShade);
+      } else { // not customized, so get the color, by shade if necessary
+        if (rule.isBackgroundShade) {
+          rule.value = getBackgroundShade(value, rule.asShade);
+        } else {
+          rule.value = getShade(value, rule.asShade);
+        }
       }
       rule.isCustomized = isCustomized;
     }

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeRulesStandard.ts
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeRulesStandard.ts
@@ -145,7 +145,8 @@ export function ThemeRulesStandardCreator() {
         name: baseSlot + shadeName,
         inherits: slotRules[baseSlot],
         asShade: shadeValue,
-        isCustomized: false
+        isCustomized: false,
+        isBackgroundShade: baseSlot == BaseSlots[BaseSlots.backgroundColor] ? true : false
       };
       return void 0;
     });


### PR DESCRIPTION
Add new logic for autogenerating shades (or tints) of the background. Generated shades of the selected background color should ALL be lighter or ALL be darker.